### PR TITLE
Remove DJANGO_ prefix from environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - postgresql
 
 env:
-  - DJANGO_DATABASE_ENGINE=django.db.backends.postgresql_psycopg2
+  - DATABASE_ENGINE=django.db.backends.postgresql_psycopg2
 
 cache:
   - pip

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,6 @@ test:
 	pip install cookiecutter
 	cookiecutter --no-input . project_name=ci_project django_app=api
 	echo "ENV=ci" > ci_project/.env
-	echo "DJANGO_ADMINS=Test Example <test@example.com>,Test2 <test2@example.com>" >> ci_project/.env
-	echo "DJANGO_DATABASE_ENGINE=django.db.backends.sqlite3" >> ci_project/.env
+	echo "ADMINS=Test Example <test@example.com>,Test2 <test2@example.com>" >> ci_project/.env
+	echo "DATABASE_ENGINE=django.db.backends.sqlite3" >> ci_project/.env
 	make -C ci_project install-dev test

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Code quality tools:
 
 
 Per default postgres is configured and a docker compose file provided. To support other database only
-`DJANGO_DATABASE_ENGINE` environment variable needs to be changed.
+`DATABASE_ENGINE` environment variable needs to be changed.
 
 License
 -------

--- a/{{cookiecutter.project_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_name}}/.gitlab-ci.yml
@@ -9,7 +9,7 @@ test:
     POSTGRES_DB: {{cookiecutter.project_name}}
     POSTGRES_USER: {{cookiecutter.project_name}}
     POSTGRES_PASSWORD: {{cookiecutter.project_name}}
-    DJANGO_DATABASE_HOST: postgres
+    DATABASE_HOST: postgres
   script:
     - echo "ENV=ci" > .env
     - make install-dev

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -7,7 +7,7 @@ import environ
 env = environ.Env()
 django_root = environ.Path(__file__) - 2
 
-ENV_FILE = env.str('DJANGO_ENV_FILE', default=django_root('.env'))
+ENV_FILE = env.str('ENV_FILE', default=django_root('.env'))
 if os.path.exists(ENV_FILE):
     environ.Env.read_env(ENV_FILE)
 
@@ -21,9 +21,9 @@ def default(default_dev=env.NOTSET, default_prod=env.NOTSET):
     return default_prod if ENV == 'production' else default_dev
 
 
-SECRET_KEY = env.str('DJANGO_SECRET_KEY', default=default('uuuuuuuuuu'))
-DEBUG = env.bool('DJANGO_DEBUG', default=default(True, False))
-ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=default(['*']))
+SECRET_KEY = env.str('SECRET_KEY', default=default('uuuuuuuuuu'))
+DEBUG = env.bool('DEBUG', default=default(True, False))
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=default(['*']))
 
 
 # Application definition
@@ -51,16 +51,16 @@ WSGI_APPLICATION = '{{cookiecutter.project_name}}.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': env.str(
-            'DJANGO_DATABASE_ENGINE',
+            'DATABASE_ENGINE',
             default='django.db.backends.postgresql_psycopg2'
         ),
-        'NAME': env.str('DJANGO_DATABASE_NAME', default='{{cookiecutter.project_name}}'),
-        'USER': env.str('DJANGO_DATABASE_USER', default='{{cookiecutter.project_name}}'),
+        'NAME': env.str('DATABASE_NAME', default='{{cookiecutter.project_name}}'),
+        'USER': env.str('DATABASE_USER', default='{{cookiecutter.project_name}}'),
         'PASSWORD': env.str(
-            'DJANGO_DATABASE_PASSWORD', default=default('{{cookiecutter.project_name}}')
+            'DATABASE_PASSWORD', default=default('{{cookiecutter.project_name}}')
         ),
-        'HOST': env.str('DJANGO_DATABASE_HOST', default='localhost'),
-        'PORT': env.str('DJANGO_DATABASE_PORT', default='')
+        'HOST': env.str('DATABASE_HOST', default='localhost'),
+        'PORT': env.str('DATABASE_PORT', default='')
     }
 }
 
@@ -78,8 +78,8 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
-LANGUAGE_CODE = env.str('DJANGO_LANGUAGE_CODE', 'en-us')
-TIME_ZONE = env.str('DJANGO_TIME_ZONE', 'UTC')
+LANGUAGE_CODE = env.str('LANGUAGE_CODE', 'en-us')
+TIME_ZONE = env.str('TIME_ZONE', 'UTC')
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
@@ -136,7 +136,7 @@ def parse_admins(admins):
     """
     Parse env admins to django admins.
 
-    Example of DJANGO_ADMINS environment variable:
+    Example of ADMINS environment variable:
     Test Example <test@example.com>,Test2 <test2@example.com>
     """
     result = []
@@ -144,10 +144,10 @@ def parse_admins(admins):
         match = re.search('(.+) \<(.+@.+)\>', admin)
         if not match:  # pragma: no cover
             raise environ.ImproperlyConfigured(
-                'In DJANGO_ADMINS admin "{0}" is not in correct '
+                'In ADMINS admin "{0}" is not in correct '
                 '"Firstname Lastname <email@example.com>"'.format(admin))
         result.append((match.group(1), match.group(2)))
     return result
 
 
-ADMINS = parse_admins(env.list('DJANGO_ADMINS', default=[]))
+ADMINS = parse_admins(env.list('ADMINS', default=[]))


### PR DESCRIPTION
Fixes #41 

We assume that this application is running in a container and there will only one process be running.

If it is still needed to run several services on a server it is recommended to use ENV_FILE anyway for simpler configuration.