### PR TITLE
Format code with black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.5"
   - "3.6"
 
 services:

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,9 @@ test:
 	echo "ENV=ci" > ci_project/.env
 	echo "ADMINS=Test Example <test@example.com>,Test2 <test2@example.com>" >> ci_project/.env
 	echo "DATABASE_ENGINE=django.db.backends.sqlite3" >> ci_project/.env
-	make -C ci_project install-dev test
+	make -C ci_project install-dev
+	# format build ci_project as line lengths have changed due to replacement
+	black ci_project
+	# not generated code needs to be check for correct formatting as well
+	black --check .
+	make -C ci_project test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Django JSON API CookieCutter template
 =====================================
 
+[![Build Status](https://travis-ci.org/adfinis-sygroup/cookiecutter-django-json-api.svg?branch=master)](https://travis-ci.org/adfinis-sygroup/cookiecutter-django-json-api)
+[![Pyup](https://pyup.io/repos/github/adfinis-sygroup/cookiecutter-django-json-api/shield.svg)](https://pyup.io/account/repos/github/adfinis-sygroup/cookiecutter-django-json-api/)
+[![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/adfinis-sygroup/cookiecutter-django-json-api)
+[![License: MIT](https://img.shields.io/badge/License-BSD-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+
 This cookie cutter provides a Django project with JSON API support. It combines Adfinis best practices in terms of setup, structure and configuration.
 
 Requirements
@@ -29,8 +34,9 @@ Django specific:
 - [Django Environ](https://github.com/joke2k/django-environ)
 
 
-Code quality tools:
+Code quality and formatting tools:
 
+- [Black](https://github.com/ambv/black)
 - [Flake8](http://flake8.pycqa.org/en/latest/) - includes .flake8 with some defaults
 - [Flake8 Debugger Plugin](https://github.com/jbkahn/flake8-debugger)
 - [Flake8 DocStrings Plugin](https://gitlab.com/pycqa/flake8-docstrings)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This cookie cutter provides a Django project with JSON API support. It combines 
 
 Requirements
 ------------
-- Latest [Python & virtualenv](https://www.python.org/downloads/release)
+- Python 3.6+
 - Latest [CookieCutter](http://cookiecutter.readthedocs.org/en/latest/)
 - Latest [Docker](https://docs.docker.com/)
 - Latest [Docker Compose](https://docs.docker.com/compose/)

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -8,14 +8,21 @@ ignore =
     E501,
     # Line break occurred before a binary operator (this is not PEP8 compatible)
     W503,
-    # do not enforce existence of docstrings
+    # Missing docstring in public module
     D100,
+    # Missing docstring in public class
     D101,
+    # Missing docstring in public method
     D102,
+    # Missing docstring in public function
     D103,
+    # Missing docstring in public package
     D104,
+    # Missing docstring in magic method
     D105,
+    # Missing docstring in public package
     D106,
+    # Missing docstring in __init__
     D107,
     # needed because of https://github.com/ambv/black/issues/144
     D202,

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -2,33 +2,25 @@
 ignore =
     # whitespace before ':'
     E203,
-    # multiple spaces before operator
-    E221,
-    # multiple spaces after operator
-    E222,
-    # multiple spaces after ','
-    E241,
-    # unexpected spaces around keyword / parameter equals
-    E251,
-    # multiple spaces after keyword
-    E272,
-    # Missing docstring in public module
+    # too many leading ### in a block comment
+    E266,
+    # line too long (managed by black)
+    E501,
+    # Line break occurred before a binary operator (this is not PEP8 compatible)
+    W503,
+    # do not enforce existence of docstrings
     D100,
-    # Missing docstring in public class
     D101,
-    # Missing docstring in public method
     D102,
-    # Missing docstring in public function
     D103,
-    # Missing docstring in public package
     D104,
-    # Missing docstring in magic method
     D105,
-    # Missing docstring in public package
     D106,
-    # Missing docstring in __init__
-    D107
-
-jobs=auto
-exclude = migrations
+    D107,
+    # needed because of https://github.com/ambv/black/issues/144
+    D202,
+    # other string does contain unindexed parameters
+    P103
+max-line-length = 80
+exclude = migrations snapshots
 max-complexity = 10

--- a/{{cookiecutter.project_name}}/.isort.cfg
+++ b/{{cookiecutter.project_name}}/.isort.cfg
@@ -1,3 +1,8 @@
 [settings]
-skip=migrations
+skip=migrations,snapshots
 known_first_party={{cookiecutter.project_name}}
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+line_length=88

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -14,5 +14,6 @@ start: ## Start the development server
 	@docker-compose up -d
 
 test: ## Test the project
+	@black --check .
 	@flake8
 	@pytest --no-cov-on-fail --cov --create-db

--- a/{{cookiecutter.project_name}}/manage.py
+++ b/{{cookiecutter.project_name}}/manage.py
@@ -6,7 +6,9 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{cookiecutter.project_name}}.settings")
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", "{{cookiecutter.project_name}}.settings"
+    )
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)

--- a/{{cookiecutter.project_name}}/requirements-dev.txt
+++ b/{{cookiecutter.project_name}}/requirements-dev.txt
@@ -1,3 +1,4 @@
+black==18.9b0
 factory-boy==2.11.1
 flake8==3.5.0
 flake8-debugger==3.1.0

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -3,11 +3,11 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='{{cookiecutter.project_name}}',
-    version='0.0.0',
-    author='Adfinis SyGroup AG',
-    author_email='https://adfinis-sygroup.ch/',
-    description='{{cookiecutter.description}}',
-    url='https://adfinis-sygroup.ch/',
+    name="{{cookiecutter.project_name}}",
+    version="0.0.0",
+    author="Adfinis SyGroup AG",
+    author_email="https://adfinis-sygroup.ch/",
+    description="{{cookiecutter.description}}",
+    url="https://adfinis-sygroup.ch/",
     packages=find_packages(),
 )

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/conftest.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/conftest.py
@@ -1,11 +1,10 @@
+import importlib
 import inspect
 
 import pytest
 from factory.base import FactoryMetaClass
 from pytest_factoryboy import register
 from rest_framework_jwt import test
-
-from .{{cookiecutter.django_app}} import factories as {{cookiecutter.django_app}}_factories
 
 
 def register_module(module):
@@ -17,7 +16,11 @@ def register_module(module):
             register(obj, base_name)
 
 
-register_module({{cookiecutter.django_app}}_factories)
+register_module(
+    importlib.import_module(
+        ".{{cookiecutter.django_app}}.factories", "{{cookiecutter.project_name}}"
+    )
+)
 
 
 @pytest.fixture
@@ -27,5 +30,5 @@ def client():
 
 @pytest.fixture
 def admin_client(db, admin_user, client):
-    client.login(username=admin_user.username, password='password')
+    client.login(username=admin_user.username, password="password")
     return client

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -7,60 +7,59 @@ import environ
 env = environ.Env()
 django_root = environ.Path(__file__) - 2
 
-ENV_FILE = env.str('ENV_FILE', default=django_root('.env'))
+ENV_FILE = env.str("ENV_FILE", default=django_root(".env"))
 if os.path.exists(ENV_FILE):
     environ.Env.read_env(ENV_FILE)
 
 # per default production is enabled for security reasons
 # for development create .env file with ENV=development
-ENV = env.str('ENV', 'production')
+ENV = env.str("ENV", "production")
 
 
 def default(default_dev=env.NOTSET, default_prod=env.NOTSET):
     """Environment aware default."""
-    return default_prod if ENV == 'production' else default_dev
+    return default_prod if ENV == "production" else default_dev
 
 
-SECRET_KEY = env.str('SECRET_KEY', default=default('uuuuuuuuuu'))
-DEBUG = env.bool('DEBUG', default=default(True, False))
-ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=default(['*']))
+SECRET_KEY = env.str("SECRET_KEY", default=default("uuuuuuuuuu"))
+DEBUG = env.bool("DEBUG", default=default(True, False))
+ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=default(["*"]))
 
 
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.postgres',
-    '{{cookiecutter.project_name}}.{{cookiecutter.django_app}}.apps.DefaultConfig',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.postgres",
+    "{{cookiecutter.project_name}}.{{cookiecutter.django_app}}.apps.DefaultConfig",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
 ]
 
-ROOT_URLCONF = '{{cookiecutter.project_name}}.urls'
-WSGI_APPLICATION = '{{cookiecutter.project_name}}.wsgi.application'
+ROOT_URLCONF = "{{cookiecutter.project_name}}.urls"
+WSGI_APPLICATION = "{{cookiecutter.project_name}}.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': env.str(
-            'DATABASE_ENGINE',
-            default='django.db.backends.postgresql_psycopg2'
+    "default": {
+        "ENGINE": env.str(
+            "DATABASE_ENGINE", default="django.db.backends.postgresql_psycopg2"
         ),
-        'NAME': env.str('DATABASE_NAME', default='{{cookiecutter.project_name}}'),
-        'USER': env.str('DATABASE_USER', default='{{cookiecutter.project_name}}'),
-        'PASSWORD': env.str(
-            'DATABASE_PASSWORD', default=default('{{cookiecutter.project_name}}')
+        "NAME": env.str("DATABASE_NAME", default="{{cookiecutter.project_name}}"),
+        "USER": env.str("DATABASE_USER", default="{{cookiecutter.project_name}}"),
+        "PASSWORD": env.str(
+            "DATABASE_PASSWORD", default=default("{{cookiecutter.project_name}}")
         ),
-        'HOST': env.str('DATABASE_HOST', default='localhost'),
-        'PORT': env.str('DATABASE_PORT', default='')
+        "HOST": env.str("DATABASE_HOST", default="localhost"),
+        "PORT": env.str("DATABASE_PORT", default=""),
     }
 }
 
@@ -68,67 +67,64 @@ DATABASES = {
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-    {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator', },  # noqa: E501
-    {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator', },  # noqa: E501
-    {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator', },  # noqa: E501
-    {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator', },  # noqa: E501
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+    },
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
-LANGUAGE_CODE = env.str('LANGUAGE_CODE', 'en-us')
-TIME_ZONE = env.str('TIME_ZONE', 'UTC')
+LANGUAGE_CODE = env.str("LANGUAGE_CODE", "en-us")
+TIME_ZONE = env.str("TIME_ZONE", "UTC")
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-AUTH_USER_MODEL = '{{cookiecutter.django_app}}.User'
+AUTH_USER_MODEL = "{{cookiecutter.django_app}}.User"
 
 REST_FRAMEWORK = {
-    'EXCEPTION_HANDLER':
-        'rest_framework_json_api.exceptions.exception_handler',
-    'DEFAULT_PAGINATION_CLASS':
-        'rest_framework_json_api.pagination.JsonApiPageNumberPagination',
-    'DEFAULT_PARSER_CLASSES': (
-        'rest_framework_json_api.parsers.JSONParser',
-        'rest_framework.parsers.JSONParser',
-        'rest_framework.parsers.FormParser',
-        'rest_framework.parsers.MultiPartParser',
+    "EXCEPTION_HANDLER": "rest_framework_json_api.exceptions.exception_handler",
+    "DEFAULT_PAGINATION_CLASS": "rest_framework_json_api.pagination.JsonApiPageNumberPagination",
+    "DEFAULT_PARSER_CLASSES": (
+        "rest_framework_json_api.parsers.JSONParser",
+        "rest_framework.parsers.JSONParser",
+        "rest_framework.parsers.FormParser",
+        "rest_framework.parsers.MultiPartParser",
     ),
-    'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework_json_api.renderers.JSONRenderer',
-        'rest_framework.renderers.JSONRenderer',
+    "DEFAULT_RENDERER_CLASSES": (
+        "rest_framework_json_api.renderers.JSONRenderer",
+        "rest_framework.renderers.JSONRenderer",
     ),
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_jwt.authentication.JSONWebTokenAuthentication",
     ),
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+    "DEFAULT_METADATA_CLASS": "rest_framework_json_api.metadata.JSONAPIMetadata",
+    "DEFAULT_FILTER_BACKENDS": (
+        "django_filters.rest_framework.DjangoFilterBackend",
+        "rest_framework.filters.SearchFilter",
+        "rest_framework.filters.OrderingFilter",
     ),
-    'DEFAULT_METADATA_CLASS':
-        'rest_framework_json_api.metadata.JSONAPIMetadata',
-    'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.DjangoFilterBackend',
-        'rest_framework.filters.SearchFilter',
-        'rest_framework.filters.OrderingFilter',
+    "ORDERING_PARAM": "sort",
+    "TEST_REQUEST_RENDERER_CLASSES": (
+        "rest_framework_json_api.renderers.JSONRenderer",
+        "rest_framework.renderers.JSONRenderer",
     ),
-    'ORDERING_PARAM': 'sort',
-    'TEST_REQUEST_RENDERER_CLASSES': (
-        'rest_framework_json_api.renderers.JSONRenderer',
-        'rest_framework.renderers.JSONRenderer',
-    ),
-    'TEST_REQUEST_DEFAULT_FORMAT': 'vnd.api+json'
+    "TEST_REQUEST_DEFAULT_FORMAT": "vnd.api+json",
 }
 
-JSON_API_FORMAT_FIELD_NAMES = 'dasherize'
-JSON_API_FORMAT_TYPES = 'dasherize'
+JSON_API_FORMAT_FIELD_NAMES = "dasherize"
+JSON_API_FORMAT_TYPES = "dasherize"
 JSON_API_PLURALIZE_TYPES = True
 
 JWT_AUTH = {
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(minutes=30),
-    'JWT_ALLOW_REFRESH': True,
+    "JWT_EXPIRATION_DELTA": datetime.timedelta(minutes=30),
+    "JWT_ALLOW_REFRESH": True,
 }
 
 
@@ -141,13 +137,14 @@ def parse_admins(admins):
     """
     result = []
     for admin in admins:
-        match = re.search('(.+) \<(.+@.+)\>', admin)
+        match = re.search("(.+) \<(.+@.+)\>", admin)
         if not match:  # pragma: no cover
             raise environ.ImproperlyConfigured(
                 'In ADMINS admin "{0}" is not in correct '
-                '"Firstname Lastname <email@example.com>"'.format(admin))
+                '"Firstname Lastname <email@example.com>"'.format(admin)
+            )
         result.append((match.group(1), match.group(2)))
     return result
 
 
-ADMINS = parse_admins(env.list('ADMINS', default=[]))
+ADMINS = parse_admins(env.list("ADMINS", default=[]))

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/urls.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/urls.py
@@ -2,7 +2,10 @@ from django.conf.urls import include, url
 from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token
 
 urlpatterns = [
-    url(r'^api-token-auth/', obtain_jwt_token),
-    url(r'^api-token-refresh/', refresh_jwt_token),
-    url(r'^api/v1/', include('{{cookiecutter.project_name}}.{{cookiecutter.django_app}}.urls')),
+    url(r"^api-token-auth/", obtain_jwt_token),
+    url(r"^api-token-refresh/", refresh_jwt_token),
+    url(
+        r"^api/v1/",
+        include("{{cookiecutter.project_name}}.{{cookiecutter.django_app}}.urls"),
+    ),
 ]

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/wsgi.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/wsgi.py
@@ -11,6 +11,8 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{cookiecutter.project_name}}.settings")
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE", "{{cookiecutter.project_name}}.settings"
+)
 
 application = get_wsgi_application()

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/apps.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class DefaultConfig(AppConfig):
-    name = '{{cookiecutter.project_name}}.{{cookiecutter.django_app}}'
+    name = "{{cookiecutter.project_name}}.{{cookiecutter.django_app}}"

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/factories.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/factories.py
@@ -5,10 +5,10 @@ from . import models
 
 
 class UserFactory(DjangoModelFactory):
-    first_name = Faker('first_name')
-    last_name = Faker('last_name')
-    username = Faker('uuid')
-    email = Faker('safe_email')
+    first_name = Faker("first_name")
+    last_name = Faker("last_name")
+    username = Faker("uuid")
+    email = Faker("safe_email")
 
     class Meta:
         model = models.User

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/migrations/0001_initial.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/migrations/0001_initial.py
@@ -12,35 +12,119 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-        ('auth', '0008_alter_user_username_max_length'),
-    ]
+    dependencies = [("auth", "0008_alter_user_username_max_length")]
 
     operations = [
         migrations.CreateModel(
-            name='User',
+            name="User",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('password', models.CharField(max_length=128, verbose_name='password')),
-                ('last_login', models.DateTimeField(blank=True, null=True, verbose_name='last login')),
-                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
-                ('username', models.CharField(error_messages={'unique': 'A user with that username already exists.'}, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()], verbose_name='username')),
-                ('first_name', models.CharField(blank=True, max_length=30, verbose_name='first name')),
-                ('last_name', models.CharField(blank=True, max_length=30, verbose_name='last name')),
-                ('email', models.EmailField(blank=True, max_length=254, verbose_name='email address')),
-                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
-                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
-                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
-                ('groups', models.ManyToManyField(blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', related_name='user_set', related_query_name='user', to='auth.Group', verbose_name='groups')),
-                ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', related_query_name='user', to='auth.Permission', verbose_name='user permissions')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("password", models.CharField(max_length=128, verbose_name="password")),
+                (
+                    "last_login",
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name="last login"
+                    ),
+                ),
+                (
+                    "is_superuser",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Designates that this user has all permissions without explicitly assigning them.",
+                        verbose_name="superuser status",
+                    ),
+                ),
+                (
+                    "username",
+                    models.CharField(
+                        error_messages={
+                            "unique": "A user with that username already exists."
+                        },
+                        help_text="Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+                        max_length=150,
+                        unique=True,
+                        validators=[
+                            django.contrib.auth.validators.UnicodeUsernameValidator()
+                        ],
+                        verbose_name="username",
+                    ),
+                ),
+                (
+                    "first_name",
+                    models.CharField(
+                        blank=True, max_length=30, verbose_name="first name"
+                    ),
+                ),
+                (
+                    "last_name",
+                    models.CharField(
+                        blank=True, max_length=30, verbose_name="last name"
+                    ),
+                ),
+                (
+                    "email",
+                    models.EmailField(
+                        blank=True, max_length=254, verbose_name="email address"
+                    ),
+                ),
+                (
+                    "is_staff",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Designates whether the user can log into this admin site.",
+                        verbose_name="staff status",
+                    ),
+                ),
+                (
+                    "is_active",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Designates whether this user should be treated as active. Unselect this instead of deleting accounts.",
+                        verbose_name="active",
+                    ),
+                ),
+                (
+                    "date_joined",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, verbose_name="date joined"
+                    ),
+                ),
+                (
+                    "groups",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="The groups this user belongs to. A user will get all permissions granted to each of their groups.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.Group",
+                        verbose_name="groups",
+                    ),
+                ),
+                (
+                    "user_permissions",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="Specific permissions for this user.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.Permission",
+                        verbose_name="user permissions",
+                    ),
+                ),
             ],
             options={
-                'verbose_name': 'user',
-                'abstract': False,
-                'verbose_name_plural': 'users',
+                "verbose_name": "user",
+                "abstract": False,
+                "verbose_name_plural": "users",
             },
-            managers=[
-                ('objects', django.contrib.auth.models.UserManager()),
-            ],
-        ),
+            managers=[("objects", django.contrib.auth.models.UserManager())],
+        )
     ]

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/serializers.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/serializers.py
@@ -5,8 +5,4 @@ from rest_framework_json_api import serializers
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
-        fields = (
-            get_user_model().REQUIRED_FIELDS + [
-                get_user_model().USERNAME_FIELD
-            ]
-        )
+        fields = get_user_model().REQUIRED_FIELDS + [get_user_model().USERNAME_FIELD]

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/tests/test_user.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/tests/test_user.py
@@ -3,12 +3,12 @@ from rest_framework import status
 
 
 def test_user_detail(admin_user, admin_client):
-    url = reverse('user-detail', args=[admin_user.id])
+    url = reverse("user-detail", args=[admin_user.id])
 
     response = admin_client.get(url)
 
     assert response.status_code == status.HTTP_200_OK
 
     json = response.json()
-    assert json['data']['id'] == str(admin_user.id)
-    assert 'password' not in json['data']['attributes']
+    assert json["data"]["id"] == str(admin_user.id)
+    assert "password" not in json["data"]["attributes"]

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/urls.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/{{cookiecutter.django_app}}/urls.py
@@ -4,6 +4,6 @@ from . import views
 
 r = SimpleRouter(trailing_slash=False)
 
-r.register(r'users', views.UserViewSet)
+r.register(r"users", views.UserViewSet)
 
 urlpatterns = r.urls


### PR DESCRIPTION
Fixes #12 
Fixes #65 

Using `importlib.import_module` to make code valid python code before generation so it can be formatted with black.

Black requires Python 3.6 so bumped version. No code changes were needed.