### PR TITLE
Set a database option default compatible with all backends

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -60,7 +60,7 @@ DATABASES = {
         ),
         "HOST": env.str("DATABASE_HOST", default="localhost"),
         "PORT": env.str("DATABASE_PORT", default=""),
-        "OPTIONS": env.dict("DATABASE_OPTIONS", default={"sslmode": "prefer"}),
+        "OPTIONS": env.dict("DATABASE_OPTIONS", default={}),
     }
 }
 


### PR DESCRIPTION
sslmode is only available on postgres but `DATABASE_ENGINE` can be changed
to anything else so the default should be compatible with those.

As sslmode is default to prefer on postgres anyway this won't make a
difference to change the default to `{}`.