### PR TITLE
Set json api spec compatible filter backends

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -107,9 +107,10 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_METADATA_CLASS": "rest_framework_json_api.metadata.JSONAPIMetadata",
     "DEFAULT_FILTER_BACKENDS": (
-        "django_filters.rest_framework.DjangoFilterBackend",
+        "rest_framework_json_api.filters.QueryParameterValidationFilter",
+        "rest_framework_json_api.filters.OrderingFilter",
+        "rest_framework_json_api.django_filters.DjangoFilterBackend",
         "rest_framework.filters.SearchFilter",
-        "rest_framework.filters.OrderingFilter",
     ),
     "ORDERING_PARAM": "sort",
     "TEST_REQUEST_RENDERER_CLASSES": (


### PR DESCRIPTION
Fixes #66 

Those have been added in DJA version [2.6.0](https://github.com/django-json-api/django-rest-framework-json-api/blob/master/CHANGELOG.md#260---2018-09-20)