### PR TITLE
Allow backend to be accessible from outside of docker container

### DIFF
--- a/{{cookiecutter.project_name}}/docker-compose.override.yml
+++ b/{{cookiecutter.project_name}}/docker-compose.override.yml
@@ -17,7 +17,7 @@ services:
       [
         "/bin/sh",
         "-c",
-        "wait-for-it.sh db:5432 -- ./manage.py migrate && ./manage.py runserver 8000",
+        "wait-for-it.sh db:5432 -- ./manage.py migrate && ./manage.py runserver 0.0.0.0:8000",
       ]
     environment:
       - ENV=dev


### PR DESCRIPTION
Currently it only listened on localhost resp. container itself.