### PR TITLE
Expose port 8000 in uwsgi

### DIFF
--- a/{{cookiecutter.project_name}}/uwsgi.ini
+++ b/{{cookiecutter.project_name}}/uwsgi.ini
@@ -1,5 +1,5 @@
 [uwsgi]
-http = 0.0.0.0:80
+http = 0.0.0.0:8000
 wsgi-file = /app/{{cookiecutter.project_name}}/wsgi.py
 max-requests = 2000
 harakiri = 5


### PR DESCRIPTION
Missed configuration option when allowing docker service to be run as different user (#89)