### PR TITLE
Add dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,6 @@
+---
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "{{cookiecutter.project_name}}"
+    update_schedule: "daily"


### PR DESCRIPTION
This is needed as manifests are not in root directory which is the default.